### PR TITLE
Speed up shared image smoke builds with Buildx cache

### DIFF
--- a/.github/workflows/shared-tauri-ci-images.yml
+++ b/.github/workflows/shared-tauri-ci-images.yml
@@ -65,21 +65,25 @@ jobs:
             image: tauri-ci-desktop
             target: ci-desktop
             platforms: linux/amd64,linux/arm64
+            smoke_platform: linux/amd64
             smoke_profile: ci-desktop
           - label: CI mobile image
             image: tauri-ci-mobile
             target: ci-mobile
             platforms: linux/amd64
+            smoke_platform: linux/amd64
             smoke_profile: ci-mobile
           - label: Dev desktop image
             image: tauri-dev-desktop
             target: dev-desktop
             platforms: linux/amd64
+            smoke_platform: linux/amd64
             smoke_profile: dev-desktop
           - label: Dev mobile image
             image: tauri-dev-mobile
             target: dev-mobile
             platforms: linux/amd64
+            smoke_platform: linux/amd64
             smoke_profile: dev-mobile
     steps:
       - name: Checkout
@@ -106,12 +110,16 @@ jobs:
             type=schedule,pattern={{date 'YYYYMMDD'}}
 
       - name: Build smoke image
-        run: |
-          docker build \
-            --file docker/ci/Dockerfile \
-            --target "${{ matrix.target }}" \
-            --tag "local-smoke:${{ matrix.target }}" \
-            .
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/ci/Dockerfile
+          target: ${{ matrix.target }}
+          platforms: ${{ matrix.smoke_platform }}
+          load: true
+          tags: local-smoke:${{ matrix.target }}
+          cache-from: type=registry,ref=${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}:buildcache,mode=max
 
       - name: Run smoke checks
         shell: bash
@@ -186,6 +194,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}:buildcache,mode=max
 
       - name: Write publish summary
         run: |

--- a/docs/reference/shared-image-implementation-spec.md
+++ b/docs/reference/shared-image-implementation-spec.md
@@ -124,7 +124,8 @@ The shared image publication workflow is responsible for:
 2. publishing all intended image families
 3. applying a consistent tag policy
 4. running smoke validation before push
-5. writing digest and tag summaries for each image
+5. reusing persistent build cache across runs
+6. writing digest and tag summaries for each image
 
 ### Cadence
 
@@ -207,6 +208,31 @@ Expected usage:
 
 - CI jobs that run inside the shared images should provide `GH_TOKEN` or `GITHUB_TOKEN` in the environment when the GitHub CLI is used.
 - Devcontainers should authenticate explicitly with `gh auth login` or an equivalent token-based flow.
+
+## Cache Strategy
+
+The shared image workflow should use persistent registry-backed Buildx cache for each published image family.
+
+Expected behaviour:
+
+- smoke builds restore prior cache state when available
+- smoke builds write cache state that the publish build in the same job can reuse
+- publish builds write the refreshed cache back to the registry for future runs
+- cache references stay image-specific rather than sharing one global cache across all targets
+
+This keeps repeat runs faster while avoiding cache collisions between desktop, mobile, CI, and dev image families.
+
+## Smoke Build Strategy
+
+Smoke validation should use Buildx rather than a separate plain `docker build`.
+
+Expected behaviour:
+
+- smoke builds load a single-platform image into the local Docker engine for `docker run` validation
+- smoke validation targets the runner-compatible platform only
+- final publish builds remain the place where multi-platform images are assembled and pushed
+
+This avoids maintaining two disconnected build paths and improves cache reuse between smoke validation and the final publish step.
 
 ## Documentation Contract
 

--- a/docs/reference/shared-image-layout.md
+++ b/docs/reference/shared-image-layout.md
@@ -76,6 +76,8 @@ Every published image should be smoke-validated for:
 
 `gh` installation is part of the shared image contract, but authentication is still environment-driven. GitHub Actions jobs should pass `GH_TOKEN` or `GITHUB_TOKEN` when invoking the CLI inside the container.
 
+Smoke validation should build a single local runner-compatible image variant for fast checks. Multi-platform publication should happen only in the final publish step.
+
 ## Related Docs
 
 - Implementation spec: [`shared-image-implementation-spec.md`](./shared-image-implementation-spec.md)


### PR DESCRIPTION
## Summary

- **Smoke build performance:** switches smoke validation from a separate plain `docker build` to `docker/build-push-action`, so the smoke and publish steps share the same Buildx cache lineage.
- **Persistent cache reuse:** adds per-image registry-backed cache refs in GHCR so repeat runs can restore and refresh build cache instead of starting cold on every hosted runner.
- **Platform split:** keeps smoke validation single-platform for fast local runner checks while reserving multi-platform assembly for the final publish step.

### Workflow and infrastructure

- **Cache strategy:** adds `cache-from` and `cache-to` for each shared image family using image-specific `:buildcache` refs.
- **Smoke strategy:** adds explicit `smoke_platform` metadata and loads a single-platform smoke image through Buildx for the existing `docker run` checks.
- **Publish behaviour:** leaves the final publish step responsible for the full declared platform set while reusing the cache warmed by the smoke build.

### Documentation

- **Reference docs:** updates the shared image layout reference and implementation spec to document the cache strategy and single-platform smoke-build model.

## Test plan

- [x] `python3` YAML parse for `.github/workflows/shared-tauri-ci-images.yml`
- [x] `docker buildx build --file docker/ci/Dockerfile --target ci-base --platform linux/amd64 --load --tag local-buildx-ci-base .`
- [x] `docker buildx build --file docker/ci/Dockerfile --target dev-base --platform linux/amd64 --load --tag local-buildx-dev-base .`
- [ ] Full GitHub Actions publish workflow run on this branch
